### PR TITLE
Recalculate WADD scores during drag

### DIFF
--- a/src/DecisionLayoutChart.ts
+++ b/src/DecisionLayoutChart.ts
@@ -517,8 +517,21 @@ export class DecisionLayoutChart {
           const delta = event.x - this.dragInfo.startX;
           let newWPos = Math.max(0, Math.min(this.dragInfo.w, this.dragInfo.startWPos + delta));
           this.dragInfo.g.select("rect.cell-pos").attr("width", newWPos - 1);
-          this.dragInfo.g.select("rect.cell-neg").attr("x", newWPos + 1).attr("width", this.dragInfo.w - newWPos - 2);
+          this.dragInfo.g
+            .select("rect.cell-neg")
+            .attr("x", newWPos + 1)
+            .attr("width", this.dragInfo.w - newWPos - 2);
           this.dragInfo.g.select("rect.score-handle").attr("x", newWPos - 2.5);
+
+          const newScore = 2 * (newWPos / this.dragInfo.w) - 1;
+          this.updateScore(this.dragInfo.d.fid, this.dragInfo.d.oid, newScore);
+          if (showWADD) {
+            const waddScores = this.calculateWADDScores();
+            this.gWADD
+              .selectAll<SVGGElement, Option>("g.wadd")
+              .select("text")
+              .text(d => `WADD: ${waddScores[d.id]}`);
+          }
         })
         .on("end", () => {
           const newWPos = Number(this.dragInfo.g.select("rect.cell-pos").attr("width")) + 1;

--- a/src/lib/vis.ts
+++ b/src/lib/vis.ts
@@ -584,8 +584,21 @@ export class DecisionLayoutChart {
           const delta = event.x - this.dragInfo.startX;
           let newWPos = Math.max(0, Math.min(this.dragInfo.w, this.dragInfo.startWPos + delta));
           this.dragInfo.g.select("rect.cell-pos").attr("width", newWPos - 1);
-          this.dragInfo.g.select("rect.cell-neg").attr("x", COL_GAP / 2 + newWPos + 1).attr("width", this.dragInfo.w - newWPos - 2);
+          this.dragInfo.g
+            .select("rect.cell-neg")
+            .attr("x", COL_GAP / 2 + newWPos + 1)
+            .attr("width", this.dragInfo.w - newWPos - 2);
           this.dragInfo.g.select("rect.score-handle").attr("x", COL_GAP / 2 + newWPos - 2.5);
+
+          const newScore = 2 * (newWPos / this.dragInfo.w) - 1;
+          this.updateScore(this.dragInfo.d.fid, this.dragInfo.d.oid, newScore);
+          if (showWADD) {
+            const waddScores = this.calculateWADDScores();
+            this.gWADD
+              .selectAll<SVGGElement, Option>("g.wadd")
+              .select("text")
+              .text(d => `WADD: ${waddScores[d.id].toFixed(2)}`);
+          }
         })
         .on("end", () => {
           const newWPos = Number(this.dragInfo.g.select("rect.cell-pos").attr("width")) + 1;


### PR DESCRIPTION
## Summary
- Recompute WADD scores live while dragging green/brown score bars
- Reflect updated WADD text in both library and chart implementations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b74e377cd483219548d99c5b7c4bdd